### PR TITLE
Java and Minecraft sever version updates

### DIFF
--- a/minecraft-server.yaml
+++ b/minecraft-server.yaml
@@ -26,9 +26,9 @@ Resources:
         Fn::Base64: !Sub |
           #!/bin/bash
           yum update -y
-          wget https://download.oracle.com/java/17/latest/jdk-17_linux-aarch64_bin.tar.gz
-          sudo tar xvf jdk-17_linux-aarch64_bin.tar.gz -C /opt
-          wget https://piston-data.mojang.com/v1/objects/8dd1a28015f51b1803213892b50b7b4fc76e594d/server.jar -O minecraft_server.jar
+          wget https://download.oracle.com/java/23/latest/jdk-23_linux-aarch64_bin.tar.gz
+          sudo tar xvf jdk-23_linux-aarch64_bin.tar.gz -C /opt
+          wget https://piston-data.mojang.com/v1/objects/4707d00eb834b446575d89a61a11b5d548d8c001/server.jar -O minecraft_server.jar
           echo 'eula=true' > eula.txt
           export JAVA_HOME=$(find /opt -type d -name "jdk*" -print -quit)
           echo 'export JAVA_HOME='$JAVA_HOME >> ~/.bashrc


### PR DESCRIPTION
1. Java JDK link in the original code no longer works - I replaced it with the latest version that works.
2. The Minecraft server version in the original code is a bit outdated - I replaced it with the latest one.

Tested with the correct ImageId, and it deployed correctly. The Minecraft server is also operable.  